### PR TITLE
ci: run push builds on the default branch only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 on:
   push:
+    branches: [main]
     paths:
       - .github/**
       - go.*


### PR DESCRIPTION
A PR branch fired both the `push` and the `pull_request` trigger, so every PR produced two identical runs. Restricting `push:` to the default branch leaves `pull_request` as the single PR signal and keeps the post-merge run on main.

Workflow config only. YAML validated with `yaml.safe_load` before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXqd1buVpwVWjyGYESYh82